### PR TITLE
Add Postgresql adaptor package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 .byebug_history
 
 /config/local_env.yml
+# Ignore encrypted secrets key file.
+config/secrets.yml.key

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ end
 gem 'coffee-rails', '~> 4.2'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'
+gem 'pg', '~>1.1.4'
 gem 'puma', '~> 3.7'
 gem 'rails', '~> 5.1.6'
 gem 'sass-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,6 +311,7 @@ GEM
     parallel (1.13.0)
     parser (2.6.0.0)
       ast (~> 2.4.0)
+    pg (1.1.4)
     powerpack (0.1.2)
     public_suffix (3.0.3)
     puma (3.12.0)
@@ -455,6 +456,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick
   net-telnet
+  pg (~> 1.1.4)
   puma (~> 3.7)
   rails (~> 5.1.6)
   rails_12factor

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,5 +21,12 @@ test:
   database: db/test.sqlite3
 
 production:
-  <<: *default
-  database: db/production.sqlite3
+  adapter: postgresql
+  database: <%= ENV['PG_DB'] %>
+  host: <%= ENV['PG_HOST'] %>
+  port: <%= ENV['PG_PORT'] %>
+  username: <%= ENV['PG_USER'] %>
+  password: <%= ENV['PG_PASSWD'] %>
+  sslmode: require
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,4 +2,6 @@
 applications:
 - memory: 512M
   instances: 1
+  buildpacks:
+  - ruby_buildpack
   random-route: true


### PR DESCRIPTION
Add `pg` package in Gemfile in order to use postgresql
adaptor. I also modified the database settings for
production environment. In production env, it will
use environment variables to pass in the postgresql
information.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>